### PR TITLE
Change logging level from log to error for catch clause

### DIFF
--- a/grpc/grpc-client-streaming.js
+++ b/grpc/grpc-client-streaming.js
@@ -62,7 +62,7 @@ module.exports = function (RED) {
                     node.status({fill:"green",shape:"dot",text: "Connected to " +  REMOTE_SERVER });
                     node.call.write(msg.payload);
                 } catch (err) {
-                    node.log("onInput" + err);
+                    node.error("onInput" + err);
                     console.log(err);
                 }
 


### PR DESCRIPTION
When trying to run second gRPC server with client stream node with same port I didn't get any information about an error, node.log didn't show it via debug node, node.error does.