### PR TITLE
Fix - don't persist channel for response stream

### DIFF
--- a/grpc/grpc-call.js
+++ b/grpc/grpc-call.js
@@ -39,18 +39,16 @@ module.exports = function (RED) {
                         } else {
                             node.status({});
                             if (proto[config.service].service[config.method].responseStream) {
-                                if (!node.channel) {
-                                    node.channel = node.client[config.method](msg.payload);
-                                    node.channel.on("data", function (data) {
-                                        msg.payload = data;
-                                        node.send(msg);
-                                    });
-    
-                                    node.channel.on("error",function (error) {
-                                        msg.error = error;
-                                        node.send(msg);
-                                    });
-                                }
+                                node.channel = node.client[config.method](msg.payload);
+                                node.channel.on("data", function (data) {
+                                    msg.payload = data;
+                                    node.send(msg);
+                                });
+
+                                node.channel.on("error",function (error) {
+                                    msg.error = error;
+                                    node.send(msg);
+                                });
                             } else {
                                 node.client[config.method](msg.payload, function(error, data) {
                                     msg.payload = data;


### PR DESCRIPTION
According to gRPC documentation, server should finished every transmission with the "end" event when sends back a stream of responses.