### PR TITLE
Fix handling of protos in dotted package

### DIFF
--- a/grpc/grpc-call.js
+++ b/grpc/grpc-call.js
@@ -1,6 +1,7 @@
 module.exports = function (RED) {
     "use strict";
     let grpc = require("grpc");
+    let getByPath = require('lodash.get');
 
     function gRpcCallNode(config) {
         try {
@@ -19,7 +20,7 @@ module.exports = function (RED) {
                     //Create gRPC client
                     var proto =  serverNode.proto;
                     if (serverNode.protoPackage) {
-                        proto = serverNode.proto[serverNode.protoPackage];
+                        proto = getByPath(serverNode.proto, serverNode.protoPackage);
                     }
                     if (!proto[config.service]) {
                         node.status({fill:"red",shape:"dot",text: "Service " + config.service + " not in proto file"});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 	],
 	"dependencies": {
 		"@grpc/proto-loader": "^0.3.0",
-		"grpc": "^1.16.0"
+		"grpc": "^1.16.0",
+		"lodash.get": "^4.4.2"
 	},
 	"author": "Julien Pal",
 	"license": "ISC"


### PR DESCRIPTION
When a proto file with `package foo.bar;` is parsed, the initial proto
object is nested like `{ foo: { bar: { <proto object> } } }`.
The code failed to handle this case, accessing the structure as
`proto['foo.bar']` rather than the correct `proto.foo.bar`.
This change treats the `serverNode.protoPackage` as a path, rather than
a key, insto the proto object. We use lodash's `get` function, which
takes care of resolving the path.