### PR TITLE
grpc-call.js: close current client connection before openning new con…

### DIFF
--- a/grpc/grpc-call.js
+++ b/grpc/grpc-call.js
@@ -54,7 +54,11 @@ module.exports = function (RED) {
                                 }
                             }
                         }
-                        
+
+                        if (node.client) {
+                            grpc.closeClient(node.client)
+                        }
+
                         node.client = new proto[config.service](
                             REMOTE_SERVER,
                             credentials || grpc.credentials.createInsecure()


### PR DESCRIPTION
…nection

The client connection was closed only when the node is refreshed by redeploying a new Node-red flow.
But a new client connection is opened for each new request, which can happen every seconds or even more often.
These unclosed connections were not cleanned by the garbage collector, probably due to cycle references inside this connection structure
which caused a memory leak (up to 80 MB / hour for one call per second).

Closing it manually before openning a new connection fixes this issue.